### PR TITLE
AppUUID and IndexUUID should be plain values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apisearch",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "Javascript client for Apisearch.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/Repository/HttpRepository.ts
+++ b/src/Repository/HttpRepository.ts
@@ -345,13 +345,17 @@ export class HttpRepository extends Repository {
     /**
      * Click
      *
-     * @param {Item} item
+     * @param {string} app_id
+     * @param {string} index_id
+     * @param {string} item_id
      * @param {string} user_id
      *
      * @return {Promise<void>}
      */
      public async click(
-        item: Item,
+        app_id: string,
+        index_id: string,
+        item_id: string,
         user_id?: string
         ): Promise<void> {
         var parameters = <any>{};
@@ -361,9 +365,11 @@ export class HttpRepository extends Repository {
 
         try {
              await this.httpClient.get(
-                 "/" + item.getAppUUID().composedUUID() + "/indices/" + item.getIndexUUID().composedUUID() + "/items/" + item.getUUID().composedUUID() + '/click',
+                 "/" + app_id + "/indices/" + index_id + "/items/" + item_id + '/click',
                  "post",
-                 this.getCredentials(),
+                 {
+                    token: this.token
+                 },
                  parameters,
                  {}
              );

--- a/test/Functional/Apisearch/Click.test.ts
+++ b/test/Functional/Apisearch/Click.test.ts
@@ -26,8 +26,10 @@ describe('Click', () => {
         await repository.flush();
         const result = await repository.query(Query.createMatchAll());
         const items = result.getItems();
+        const nItem0 = items[0];
+        const nItem1 = items[1];
 
-        await repository.click(items[0], 'user1234');
-        await repository.click(items[1], 'user5678');
+        await repository.click(nItem0.getAppUUID().composedUUID(), nItem0.getIndexUUID().composedUUID(), nItem0.getUUID().composedUUID(), 'user1234');
+        await repository.click(nItem1.getAppUUID().composedUUID(), nItem1.getIndexUUID().composedUUID(), nItem1.getUUID().composedUUID(), 'user5678');
     });
 });


### PR DESCRIPTION
- This click call will be placed in browser DOM as plain JS text, so we
cannot work with objects. Using plain strings make things easier.